### PR TITLE
Add mesa to dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,8 @@ requirements:
     - openblas
     # See https://conda-forge.org/docs/maintainer/knowledge_base.html#libgl
     - xorg-libxfixes  # [linux]
+    # not all platforms have libGL.so
+    - mesa-libgl-cos6-x86_64
   run:
     - eccodes
     - magics-metview
@@ -57,6 +59,7 @@ requirements:
     - gdbm
     - fftw
     - openblas
+    - mesa-libgl-cos6-x86_64
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
Metview running on Binder has a problem because uPlotBatch is linked with libGL.so, but this does not exist on their system. An ideal solution would be to have a third conda version of Magics that has ENABLE_METVIEW_NO_QT and then a second conda version of Metview that would use this (i.e. batch only operations). But for now, we will add mesa to the dependencies to see if that gets around the problem.
-->
